### PR TITLE
Enable Updates for installed instances #13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ def buildInstaller() {
     sh "yarn --frozen-lockfile --force"
     sh "rm -rf ./${distFolder}"
     sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-        sh "yarn package"
+        sh "yarn deploy"
     }
 }
 
@@ -177,6 +177,8 @@ def uploadInstaller(String platform) {
             sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/${version}/${platform}"
             sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/${version}/${platform}"
             sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/${version}/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/latest"
+            sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/latest"
         }
     } else {
         echo "Skipped upload for branch ${env.BRANCH_NAME}"

--- a/electron-app/electron-builder.yml
+++ b/electron-app/electron-builder.yml
@@ -60,4 +60,7 @@ deb:
   artifactName: ${productName}-${version}.${ext}
 
 afterPack: ./scripts/after-pack.js
-  
+
+publish:
+  provider: generic
+  url: "https://download.eclipse.org/theia/latest/"

--- a/electron-app/scripts/after-pack.js
+++ b/electron-app/scripts/after-pack.js
@@ -24,7 +24,8 @@ const signFile = file => {
         path.basename(file),
         entitlements
     ], {
-        cwd: path.dirname(file)
+        cwd: path.dirname(file),
+        maxBuffer: 1024 * 10000
     });
 
     if (mode) {
@@ -67,6 +68,7 @@ exports.default = async function(context) {
         path.basename(appPath),
         context.packager.appInfo.info._configuration.appId
     ], {
-        cwd: path.dirname(appPath)
+        cwd: path.dirname(appPath),
+        maxBuffer: 1024 * 10000
     });
 }

--- a/theia-example-updater/package.json
+++ b/theia-example-updater/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@theia/core": "^1.9.0",
     "@theia/output": "^1.9.0",
+    "@theia/preferences": "^1.9.0",
     "electron-updater": "^4.3.5",
     "electron-log": "^4.3.0"
   },

--- a/theia-example-updater/src/electron-browser/theia-updater-frontend-module.ts
+++ b/theia-example-updater/src/electron-browser/theia-updater-frontend-module.ts
@@ -22,9 +22,11 @@ import { AboutDialog } from '@theia/core/lib/browser/about-dialog';
 import { ContainerModule } from 'inversify';
 import { ElectronIpcConnectionProvider } from '@theia/core/lib/electron-browser/messaging/electron-ipc-connection-provider';
 import { GettingStartedWidget } from '@theia/getting-started/lib/browser/getting-started-widget';
+import { PreferenceContribution } from '@theia/core/lib/browser';
 import { TheiaInstallerAboutDialog } from './customization/theia-installer-about-dialog';
 import { TheiaInstallerGettingStartedWidget } from './customization/theia-installer-getting-started-widget';
 import { WidgetFactory } from '@theia/core/lib/browser';
+import { theiaUpdaterPreferenceSchema } from './updater/theia-updater-preferences';
 
 export default new ContainerModule((bind, _unbind, isBound, rebind) => {
     bind(ElectronMenuUpdater).toSelf().inSingletonScope();
@@ -45,4 +47,6 @@ export default new ContainerModule((bind, _unbind, isBound, rebind) => {
     })).inSingletonScope();
 
     isBound(AboutDialog) ? rebind(AboutDialog).to(TheiaInstallerAboutDialog).inSingletonScope() : bind(AboutDialog).to(TheiaInstallerAboutDialog).inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: theiaUpdaterPreferenceSchema });
 });

--- a/theia-example-updater/src/electron-browser/updater/theia-updater-preferences.ts
+++ b/theia-example-updater/src/electron-browser/updater/theia-updater-preferences.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2020 TypeFox, EclipseSource and others.
+ * Copyright (C) 2020 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,19 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 
-export const TheiaUpdaterPath = '/services/theia-updater';
-export const TheiaUpdater = Symbol('TheiaUpdater');
-export interface TheiaUpdater extends JsonRpcServer<TheiaUpdaterClient> {
-    checkForUpdates(): void;
-    downloadUpdate(): void;
-    onRestartToUpdateRequested(): void;
-    disconnectClient(client: TheiaUpdaterClient): void;
-}
+import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
 
-export const TheiaUpdaterClient = Symbol('TheiaUpdaterClient');
-export interface TheiaUpdaterClient {
-    updateAvailable(available: boolean, startupCheck: boolean): void;
-    notifyReadyToInstall(): void;
-}
+export const theiaUpdaterPreferenceSchema: PreferenceSchema = {
+    'type': 'object',
+    'properties': {
+        'updates.reportOnStart': {
+            type: 'boolean',
+            description: 'Report available updates after application start.',
+            default: true
+        }
+    }
+};

--- a/theia-example-updater/src/electron-main/update/theia-updater-impl.ts
+++ b/theia-example-updater/src/electron-main/update/theia-updater-impl.ts
@@ -35,13 +35,14 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
     constructor() {
         autoUpdater.autoDownload = false
         autoUpdater.on('update-available', () => {
+            const startupCheck = this.initialCheck;
             if (this.initialCheck) {
                 this.initialCheck = false;
                 if (this.clients.length === 0) {
                     this.reportOnFirstRegistration = true;
                 }
             }
-            this.clients.forEach(c => c.updateAvailable(true))
+            this.clients.forEach(c => c.updateAvailable(true, startupCheck))
         })
         autoUpdater.on('update-not-available', () => {
             if (this.initialCheck) {
@@ -49,7 +50,7 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
                 /* do not report that no update is available on start up */
                 return;
             }
-            this.clients.forEach(c => c.updateAvailable(false))
+            this.clients.forEach(c => c.updateAvailable(false, false))
         })
 
         autoUpdater.on('update-downloaded', () => {
@@ -83,7 +84,7 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
             this.clients.push(client);
             if (this.reportOnFirstRegistration) {
                 this.reportOnFirstRegistration = false;
-                this.clients.forEach(c => c.updateAvailable(true))
+                this.clients.forEach(c => c.updateAvailable(true, true))
             }
         }
     }


### PR DESCRIPTION
This PR resolves #13

Besides deploying to version and platform specfic directories (e.g. https://download.eclipse.org/theia/1.9.0/linux/) we will also deploy to https://download.eclipse.org/theia/latest
The latest location will be used to fetch the latest updates. 

The application will check for updates after each launch. Checking for updates may also be triggered from the application menu. 
When an update is available, the user will be notified and may start the upgrade. 
Users may disable the notification for the automatic update check after program launch via preferences. 


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
* application will check for updates after the application is launched
* if update available prompt the user
* add preference to disable to check on startup
* use https://download.eclipse.org/theia/latest/ as location where the
latest version of theia will be deployed to. this will serve the updates

Signed-off-by: Johannes Faltermeier <jfaltermeier@eclipsesource.com>
Contributed on behalf of STMicroelectronics

#### How to test
For local testing we changed `https://download.eclipse.org/theia/latest/` in `electron-builder.yml` to a `localhost`-address where we started a small http server serving the updates. 
For testing the actual update mechanism we need to publish to `https://download.eclipse.org/theia/latest/` first. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

